### PR TITLE
Adding a Django development environment

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+django = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,45 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c36ae28fea7b9a4cc02145632e2f41469af2e7b38b801903abb8333d3306f36b"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0",
+                "sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.5.0"
+        },
+        "django": {
+            "hashes": [
+                "sha256:110fb58fb12eca59e072ad59fc42d771cd642dd7a2f2416582aa9da7a8ef954a",
+                "sha256:996495c58bff749232426c88726d8cd38d24c94d7c1d80835aafffa9bc52985a"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae",
+                "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.2"
+        }
+    },
+    "develop": {}
+}

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'beyond_tutorial.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+# The -e option would make our script exit with an error if any command
+# fails while the -x option makes verbosely it output what it does
+
+# Install Pipenv, the -n option makes sudo fail instead of asking for a
+# password if we don’t have sufficient privileges to run it
+sudo -n dnf install -y pipenv
+
+cd /vagrant
+# Install dependencies with Pipenv
+pipenv sync --dev
+
+# Run database migrations
+pipenv run python manage.py migrate
+
+# run our app. Nohup and “&” are used to let the setup script finish
+# while our app stays up. The app logs will be collected in nohup.out
+nohup pipenv run python manage.py runserver 0.0.0.0:8000 &


### PR DESCRIPTION
- Setup [Pipenv][1] to install and manage Django and other Python
dependencies
- Bootstrapped an empty [Django][2] application
- Setup Vagrant to automatically bring our application up as well as
make it accessible from a web browser
After running `vagrant up` the application can be accessed at:
> http://127.0.0.1:8000/
**Note:** Most changes had been auto-generated, only `Vagrantfile` and
`steup.sh` had been edited manually.
[1]: https://github.com/pypa/pipenv
[2]: https://www.djangoproject.com/